### PR TITLE
SPOI-5113: Added validation for root operator to be input operator in logical plan validation

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -1154,6 +1154,14 @@ public class LogicalPlan implements Serializable, DAG
       }
     }
 
+    // Validate root operators are input operators 
+    for (OperatorMeta om : this.rootOperators) {
+      if (!(om.getOperator() instanceof InputOperator)) {
+        throw new ValidationException(String.format("Root operator: %s is not a Input operator",
+            om.getName()));
+      }
+    }
+
     // processing mode
     Set<OperatorMeta> visited = Sets.newHashSet();
     for (OperatorMeta om : this.rootOperators) {

--- a/engine/src/test/java/com/datatorrent/stram/AlertsManagerTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/AlertsManagerTest.java
@@ -29,6 +29,7 @@ import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.common.util.FSStorageAgent;
 import com.datatorrent.stram.StreamingContainerManager.ContainerResource;
 import com.datatorrent.stram.engine.GenericTestOperator;
+import com.datatorrent.stram.engine.TestGeneratorInputOperator;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
 import com.datatorrent.stram.plan.physical.PTOperator;
 import com.datatorrent.stram.support.StramTestSupport.TestMeta;
@@ -48,7 +49,10 @@ public class AlertsManagerTest
     dag.setAttribute(com.datatorrent.api.Context.DAGContext.APPLICATION_PATH, testMeta.dir);
     dag.setAttribute(OperatorContext.STORAGE_AGENT, new FSStorageAgent(testMeta.dir, null));
 
-    dag.addOperator("o", GenericTestOperator.class);
+    TestGeneratorInputOperator in = dag.addOperator("in", TestGeneratorInputOperator.class);
+    GenericTestOperator o = dag.addOperator("o", GenericTestOperator.class);
+    dag.addStream("stream", in.outport, o.inport1);
+
     final StreamingContainerManager dnm = new StreamingContainerManager(dag);
     Assert.assertNotNull(dnm.assignContainer(new ContainerResource(0, "container1", "localhost", 0, 0, null), InetSocketAddress.createUnresolved("localhost", 0)));
 
@@ -102,8 +106,8 @@ public class AlertsManagerTest
     Assert.assertNotNull(alertsManager.getAlert("alertName"));
 
     // make sure we have the operators
-    Assert.assertEquals("there should be 4 operators", 4, dag.getAllOperators().size());
-    Assert.assertEquals("there should be 3 streams", 3, dag.getAllStreams().size());
+    Assert.assertEquals("there should be 5 operators", 5, dag.getAllOperators().size());
+    Assert.assertEquals("there should be 4 streams", 4, dag.getAllStreams().size());
 
     // delete the alert
     alertsManager.deleteAlert("alertName");
@@ -111,8 +115,8 @@ public class AlertsManagerTest
     Assert.assertEquals("there should be no more alerts after delete", 0, alerts.getJSONArray("alerts").length());
 
     // make sure the operators are removed
-    Assert.assertEquals("there should be 1 operator", 1, dag.getAllOperators().size());
-    Assert.assertEquals("there should be 0 stream", 0, dag.getAllStreams().size());
+    Assert.assertEquals("there should be 2 operator", 2, dag.getAllOperators().size());
+    Assert.assertEquals("there should be 1 stream", 1, dag.getAllStreams().size());
 
     t.interrupt();
     try {

--- a/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
@@ -32,6 +32,7 @@ import com.datatorrent.common.util.FSStorageAgent;
 import com.datatorrent.stram.StreamingContainerManager;
 import com.datatorrent.stram.engine.GenericTestOperator;
 import com.datatorrent.stram.engine.OperatorContext;
+import com.datatorrent.stram.engine.TestGeneratorInputOperator;
 import com.datatorrent.stram.plan.TestPlanContext;
 import com.datatorrent.stram.plan.logical.requests.CreateOperatorRequest;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
@@ -302,7 +303,7 @@ public class LogicalPlanModificationTest
 
 
     CreateOperatorRequest cor = new CreateOperatorRequest();
-    cor.setOperatorFQCN(GenericTestOperator.class.getName());
+    cor.setOperatorFQCN(TestGeneratorInputOperator.class.getName());
     cor.setOperatorName("o1");
 
     FutureTask<?> lpmf = dnm.logicalPlanModification(Collections.<LogicalPlanRequest>singletonList(cor));
@@ -326,7 +327,7 @@ public class LogicalPlanModificationTest
 
     PTOperator oper = c.getOperators().get(0);
     Assert.assertEquals("operator name", "o1", oper.getOperatorMeta().getName());
-    Assert.assertEquals("operator class", GenericTestOperator.class, oper.getOperatorMeta().getOperator().getClass());
+    Assert.assertEquals("operator class", TestGeneratorInputOperator.class, oper.getOperatorMeta().getOperator().getClass());
 
   }
 

--- a/engine/src/test/java/com/datatorrent/stram/engine/TestGeneratorInputOperator.java
+++ b/engine/src/test/java/com/datatorrent/stram/engine/TestGeneratorInputOperator.java
@@ -37,8 +37,9 @@ public class TestGeneratorInputOperator implements InputOperator
   private int remainingSleepTime;
   private int emitInterval = 1000;
   private final int spinMillis = 50;
+  private String myStringProperty;
   private final ConcurrentLinkedQueue<String> externallyAddedTuples = new ConcurrentLinkedQueue<String>();
-  @OutputPortFieldAnnotation(optional = false)
+  @OutputPortFieldAnnotation(optional = true)
   public final transient DefaultOutputPort<Object> outport = new DefaultOutputPort<Object>();
 
   public int getMaxTuples()
@@ -128,6 +129,15 @@ public class TestGeneratorInputOperator implements InputOperator
   public void teardown()
   {
   }
+
+  public String getMyStringProperty() {
+	  return myStringProperty;
+	}
+
+	public void setMyStringProperty(String myStringProperty) {
+	  this.myStringProperty = myStringProperty;
+	}
+
 
   public static class InvalidInputOperator extends TestGeneratorInputOperator implements InputOperator
   {

--- a/engine/src/test/java/com/datatorrent/stram/engine/TestNonOptionalOutportInputOperator.java
+++ b/engine/src/test/java/com/datatorrent/stram/engine/TestNonOptionalOutportInputOperator.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.stram.engine;
+
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.OutputPortFieldAnnotation;
+
+public class TestNonOptionalOutportInputOperator extends TestGeneratorInputOperator{
+
+  @OutputPortFieldAnnotation(optional = false)
+  public final transient DefaultOutputPort<Object> outport1 = new DefaultOutputPort<Object>();
+
+}

--- a/engine/src/test/java/com/datatorrent/stram/plan/LogicalPlanConfigurationTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/LogicalPlanConfigurationTest.java
@@ -47,6 +47,7 @@ import com.datatorrent.common.util.BasicContainerOptConfigurator;
 import com.datatorrent.stram.PartitioningTest.PartitionLoadWatch;
 import com.datatorrent.stram.client.StramClientUtils;
 import com.datatorrent.stram.engine.GenericTestOperator;
+import com.datatorrent.stram.engine.TestGeneratorInputOperator;
 import com.datatorrent.stram.plan.LogicalPlanTest.ValidationTestOperator;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
 import com.datatorrent.stram.plan.logical.LogicalPlan.OperatorMeta;
@@ -91,8 +92,8 @@ public class LogicalPlanConfigurationTest {
     assertEquals("operatorId set", "operator1", operator1.getName());
 
     // verify operator instantiation
-    assertEquals(operator1.getOperator().getClass(), GenericTestOperator.class);
-    GenericTestOperator GenericTestNode = (GenericTestOperator)operator1.getOperator();
+    assertEquals(operator1.getOperator().getClass(), TestGeneratorInputOperator.class);
+    TestGeneratorInputOperator GenericTestNode = (TestGeneratorInputOperator)operator1.getOperator();
     assertEquals("myStringPropertyValue", GenericTestNode.getMyStringProperty());
 
     // check links
@@ -102,7 +103,7 @@ public class LogicalPlanConfigurationTest {
     assertNotNull("n1n2", n1n2);
 
     // output/input stream object same
-    assertEquals("rootNode out is operator2 in", n1n2, operator1.getOutputStreams().get(operator1.getMeta(((GenericTestOperator)operator1.getOperator()).outport1)));
+    assertEquals("rootNode out is operator2 in", n1n2, operator1.getOutputStreams().get(operator1.getMeta(((TestGeneratorInputOperator)operator1.getOperator()).outport)));
     assertEquals("n1n2 source", operator1, n1n2.getSource().getOperatorMeta());
     Assert.assertEquals("n1n2 targets", 1, n1n2.getSinks().size());
     Assert.assertEquals("n1n2 target", operator2, n1n2.getSinks().get(0).getOperatorWrapper());

--- a/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
@@ -199,12 +199,14 @@ public class PhysicalPlanTest
     LogicalPlan dag = new LogicalPlan();
     dag.setAttribute(OperatorContext.STORAGE_AGENT, new StramTestSupport.MemoryStorageAgent());
 
+    TestGeneratorInputOperator node0 = dag.addOperator("node0", TestGeneratorInputOperator.class);
     GenericTestOperator node1 = dag.addOperator("node1", GenericTestOperator.class);
     PartitioningTestOperator partitioned = dag.addOperator("partitioned", PartitioningTestOperator.class);
     partitioned.setPartitionCount(partitioned.partitionKeys.length);
     GenericTestOperator singleton1 = dag.addOperator("singleton1", GenericTestOperator.class);
     GenericTestOperator singleton2 = dag.addOperator("singleton2", GenericTestOperator.class);
 
+    dag.addStream("n0.inport1", node0.outport, node1.inport1);
     dag.addStream("n1.outport1", node1.outport1, partitioned.inport1, partitioned.inportWithCodec);
     dag.addStream("mergeStream", partitioned.outport1, singleton1.inport1, singleton2.inport1);
 

--- a/engine/src/test/resources/dt-site.xml
+++ b/engine/src/test/resources/dt-site.xml
@@ -15,7 +15,7 @@
 
   <property>
     <name>dt.operator.operator1.classname</name>
-    <value>com.datatorrent.stram.engine.GenericTestOperator</value>
+    <value>com.datatorrent.stram.engine.TestGeneratorInputOperator</value>
     <description>The root operator</description>
   </property>
 
@@ -38,7 +38,7 @@
 
   <property>
     <name>dt.stream.n1n2.source</name>
-    <value>operator1.outport1</value>
+    <value>operator1.outport</value>
     <description></description>
   </property>
 
@@ -106,7 +106,7 @@
 
   <property>
     <name>dt.operator.operator6.classname</name>
-    <value>com.datatorrent.stram.engine.GenericTestOperator</value>
+    <value>com.datatorrent.stram.engine.TestGeneratorInputOperator</value>
     <description>Another operator, which gets input from root</description>
   </property>
 


### PR DESCRIPTION
Added validation for root operator should be input operator in logical plan validation
And updated logical plan test cases to pass this validation