### PR TITLE
Token authentication support for buffer server

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/auth/AuthManager.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/auth/AuthManager.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.bufferserver.auth;
+
+import java.security.SecureRandom;
+
+/**
+ * <p>Auth Manager class.</p>
+ */
+public class AuthManager
+{
+  private final static int BUFFER_SERVER_TOKEN_LENGTH = 20;
+
+  private static SecureRandom generator = new SecureRandom();
+
+  public static byte[] generateToken()
+  {
+    byte[] token = new byte[BUFFER_SERVER_TOKEN_LENGTH];
+    generator.nextBytes(token);
+    return token;
+  }
+}

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/client/AuthClient.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/client/AuthClient.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.bufferserver.client;
+
+import java.security.AccessControlException;
+
+import com.datatorrent.netlet.AbstractLengthPrependerClient;
+
+/**
+ * <p>Auth Client class.</p>
+ */
+public abstract class AuthClient extends AbstractLengthPrependerClient
+{
+  private byte[] token;
+
+  public AuthClient()
+  {
+  }
+
+  public AuthClient(int readBufferSize, int sendBufferSize)
+  {
+    super(readBufferSize, sendBufferSize);
+  }
+
+  public AuthClient(byte[] readbuffer, int position, int sendBufferSize)
+  {
+    super(readbuffer, position, sendBufferSize);
+  }
+
+  protected void sendAuthenticate() {
+    if (token != null) {
+      write(token);
+    }
+  }
+
+  protected void authenticateMessage(byte[] buffer, int offset, int size)
+  {
+    if (token != null) {
+      boolean authenticated = false;
+      if (size == token.length) {
+        int match = 0;
+        while ((match < token.length) && (buffer[offset + match] == token[match])) {
+          ++match;
+        }
+        if (match == token.length) {
+          authenticated = true;
+        }
+      }
+      if (!authenticated) {
+        throw new AccessControlException("Buffer server security is enabled. Access is restricted without proper credentials.");
+      }
+    }
+  }
+
+  public void setToken(byte[] token)
+  {
+    this.token = token;
+  }
+}

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Controller.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Controller.java
@@ -31,7 +31,7 @@ import com.datatorrent.netlet.util.Slice;
 *
  * @since 0.3.2
  */
-public abstract class Controller extends AbstractLengthPrependerClient
+public abstract class Controller extends AuthClient
 {
   String id;
 
@@ -43,12 +43,14 @@ public abstract class Controller extends AbstractLengthPrependerClient
 
   public void purge(String version, String sourceId, long windowId)
   {
+    sendAuthenticate();
     write(PurgeRequestTuple.getSerializedRequest(version, sourceId, windowId));
     logger.debug("Sent purge request sourceId = {}, windowId = {}", sourceId, Codec.getStringWindowId(windowId));
   }
 
   public void reset(String version, String sourceId, long windowId)
   {
+    sendAuthenticate();
     write(ResetRequestTuple.getSerializedRequest(version, sourceId, windowId));
     logger.debug("Sent reset request sourceId = {}, windowId = {}", sourceId, Codec.getStringWindowId(windowId));
   }

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Publisher.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Publisher.java
@@ -20,14 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datatorrent.bufferserver.packet.PublishRequestTuple;
-import com.datatorrent.netlet.AbstractLengthPrependerClient;
 
 /**
  * <p>Abstract Publisher class.</p>
  *
  * @since 0.3.2
  */
-public abstract class Publisher extends AbstractLengthPrependerClient
+public abstract class Publisher extends AuthClient
 {
   private final String id;
 
@@ -48,6 +47,7 @@ public abstract class Publisher extends AbstractLengthPrependerClient
    */
   public void activate(String version, long windowId)
   {
+    sendAuthenticate();
     write(PublishRequestTuple.getSerializedRequest(version, id, windowId));
   }
 

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Subscriber.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/client/Subscriber.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datatorrent.bufferserver.packet.SubscribeRequestTuple;
-import com.datatorrent.netlet.AbstractLengthPrependerClient;
 
 /**
  *
@@ -34,7 +33,7 @@ import com.datatorrent.netlet.AbstractLengthPrependerClient;
  *
  * @since 0.3.2
  */
-public abstract class Subscriber extends AbstractLengthPrependerClient
+public abstract class Subscriber extends AuthClient
 {
   private final String id;
 
@@ -46,6 +45,7 @@ public abstract class Subscriber extends AbstractLengthPrependerClient
 
   public void activate(String version, String type, String sourceId, int mask, Collection<Integer> partitions, long windowId, int bufferSize)
   {
+    sendAuthenticate();
     write(SubscribeRequestTuple.getSerializedRequest(
             version,
             id,

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
@@ -37,11 +37,11 @@ import com.datatorrent.bufferserver.internal.LogicalNode;
 import com.datatorrent.bufferserver.packet.*;
 import com.datatorrent.bufferserver.storage.Storage;
 import com.datatorrent.common.util.NameableThreadFactory;
-import com.datatorrent.netlet.util.VarInt;
 import com.datatorrent.netlet.AbstractLengthPrependerClient;
 import com.datatorrent.netlet.DefaultEventLoop;
 import com.datatorrent.netlet.EventLoop;
 import com.datatorrent.netlet.Listener.ServerListener;
+import com.datatorrent.netlet.util.VarInt;
 
 /**
  * The buffer server application<p>
@@ -60,6 +60,8 @@ public class Server implements ServerListener
   private InetSocketAddress address;
   private final ExecutorService serverHelperExecutor;
   private final ExecutorService storageHelperExecutor;
+
+  private byte[] authToken;
 
   /**
    * @param port - port number to bind to or 0 to auto select a free port
@@ -120,6 +122,11 @@ public class Server implements ServerListener
 
     this.eventloop = eventloop;
     return address;
+  }
+
+  public void setAuthToken(byte[] authToken)
+  {
+    this.authToken = authToken;
   }
 
   /**
@@ -322,7 +329,15 @@ public class Server implements ServerListener
   @Override
   public ClientListener getClientConnection(SocketChannel sc, ServerSocketChannel ssc)
   {
-    return new UnidentifiedClient(sc);
+    ClientListener client;
+    if (authToken == null) {
+      client = new UnidentifiedClient();
+    } else {
+      AuthClient authClient = new AuthClient();
+      authClient.setToken(authToken);
+      client = authClient;
+    }
+    return client;
   }
 
   @Override
@@ -335,15 +350,37 @@ public class Server implements ServerListener
     throw new RuntimeException(cce);
   }
 
-  class UnidentifiedClient extends AbstractLengthPrependerClient
+  class AuthClient extends com.datatorrent.bufferserver.client.AuthClient
   {
-    SocketChannel channel;
     boolean ignore;
 
-    UnidentifiedClient(SocketChannel channel)
+    @Override
+    public void onMessage(byte[] buffer, int offset, int size)
     {
-      this.channel = channel;
+      if (ignore) {
+        return;
+      }
+
+      authenticateMessage(buffer, offset, size);
+
+      unregistered(key);
+      UnidentifiedClient client = new UnidentifiedClient();
+      key.attach(client);
+      key.interestOps(SelectionKey.OP_READ);
+      client.registered(key);
+
+      int len = writeOffset - readOffset - size;
+      if (len > 0) {
+        client.transferBuffer(buffer, readOffset + size, len);
+      }
+
+      ignore = true;
     }
+  }
+
+  class UnidentifiedClient extends SeedDataClient
+  {
+    boolean ignore;
 
     @Override
     public void onMessage(byte[] buffer, int offset, int size)
@@ -559,7 +596,7 @@ public class Server implements ServerListener
    * this is the end on the server side which handles all the communication.
    *
    */
-  class Publisher extends AbstractLengthPrependerClient
+  class Publisher extends SeedDataClient
   {
     private final DataList datalist;
     boolean dirty;
@@ -568,26 +605,6 @@ public class Server implements ServerListener
     {
       super(dl.getBuffer(windowId), dl.getPosition(), 1024);
       this.datalist = dl;
-    }
-
-    public void transferBuffer(byte[] array, int offset, int len)
-    {
-      int remainingCapacity;
-      do {
-        remainingCapacity = buffer.length - writeOffset;
-        if (len < remainingCapacity) {
-          remainingCapacity = len;
-          byteBuffer.position(writeOffset + remainingCapacity);
-        }
-        else {
-          byteBuffer.position(buffer.length);
-        }
-        System.arraycopy(array, offset, buffer, writeOffset, remainingCapacity);
-        read(remainingCapacity);
-
-        offset += remainingCapacity;
-      }
-      while ((len -= remainingCapacity) > 0);
     }
 
     @Override
@@ -746,6 +763,44 @@ public class Server implements ServerListener
       }
     }
 
+  }
+
+  abstract class SeedDataClient extends AbstractLengthPrependerClient
+  {
+
+    public SeedDataClient()
+    {
+    }
+
+    public SeedDataClient(int readBufferSize, int sendBufferSize)
+    {
+      super(readBufferSize, sendBufferSize);
+    }
+
+    public SeedDataClient(byte[] readbuffer, int position, int sendBufferSize)
+    {
+      super(readbuffer, position, sendBufferSize);
+    }
+
+    public void transferBuffer(byte[] array, int offset, int len)
+    {
+      int remainingCapacity;
+      do {
+        remainingCapacity = buffer.length - writeOffset;
+        if (len < remainingCapacity) {
+          remainingCapacity = len;
+          byteBuffer.position(writeOffset + remainingCapacity);
+        }
+        else {
+          byteBuffer.position(buffer.length);
+        }
+        System.arraycopy(array, offset, buffer, writeOffset, remainingCapacity);
+        read(remainingCapacity);
+
+        offset += remainingCapacity;
+      }
+      while ((len -= remainingCapacity) > 0);
+    }
   }
 
   private static final Logger logger = LoggerFactory.getLogger(Server.class);

--- a/bufferserver/src/test/java/com/datatorrent/bufferserver/support/Subscriber.java
+++ b/bufferserver/src/test/java/com/datatorrent/bufferserver/support/Subscriber.java
@@ -15,13 +15,14 @@
  */
 package com.datatorrent.bufferserver.support;
 
-import com.datatorrent.bufferserver.packet.Tuple;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.datatorrent.bufferserver.packet.Tuple;
 
 /**
  *

--- a/engine/src/main/java/com/datatorrent/stram/LaunchContainerRunnable.java
+++ b/engine/src/main/java/com/datatorrent/stram/LaunchContainerRunnable.java
@@ -49,8 +49,8 @@ import org.apache.log4j.DTLoggerFactory;
 import com.datatorrent.api.Context;
 import com.datatorrent.api.DAG;
 import com.datatorrent.api.StreamingApplication;
-import com.datatorrent.stram.client.StramClientUtils;
 
+import com.datatorrent.stram.client.StramClientUtils;
 import com.datatorrent.stram.engine.StreamingContainer;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
 import com.datatorrent.stram.plan.physical.PTOperator;

--- a/engine/src/main/java/com/datatorrent/stram/StreamingAppMasterService.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingAppMasterService.java
@@ -19,7 +19,6 @@
 */
 package com.datatorrent.stram;
 
-import com.datatorrent.stram.api.AppDataSource;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -71,6 +70,7 @@ import com.datatorrent.api.DAG;
 import com.datatorrent.api.StringCodec;
 
 import com.datatorrent.stram.StreamingContainerManager.ContainerResource;
+import com.datatorrent.stram.api.AppDataSource;
 import com.datatorrent.stram.api.BaseContext;
 import com.datatorrent.stram.api.StramEvent;
 import com.datatorrent.stram.appdata.AppDataPushAgent;
@@ -504,7 +504,7 @@ public class StreamingAppMasterService extends CompositeService
   protected void serviceStart() throws Exception
   {
     super.serviceStart();
-    if (delegationTokenManager != null) {
+    if (UserGroupInformation.isSecurityEnabled()) {
       delegationTokenManager.startThreads();
     }
 
@@ -543,7 +543,7 @@ public class StreamingAppMasterService extends CompositeService
   protected void serviceStop() throws Exception
   {
     super.serviceStop();
-    if (delegationTokenManager != null) {
+    if (UserGroupInformation.isSecurityEnabled()) {
       delegationTokenManager.stopThreads();
     }
     if (nmClient != null) {

--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
@@ -19,12 +19,13 @@ import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.apache.hadoop.yarn.api.ApplicationConstants;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Sets;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import com.datatorrent.api.Context.PortContext;
 import com.datatorrent.api.DAG.Locality;
@@ -189,6 +190,7 @@ public class StreamingContainerAgent {
         if (!out.isDownStreamInline()) {
           portInfo.bufferServerHost = oper.getContainer().bufferServerAddress.getHostName();
           portInfo.bufferServerPort = oper.getContainer().bufferServerAddress.getPort();
+          portInfo.bufferServerToken = oper.getContainer().getBufferServerToken();
           // Build the stream codec configuration of all sinks connected to this port
           for (PTOperator.PTInput input : out.sinks) {
             // Create mappings for all non-inline operators
@@ -254,12 +256,14 @@ public class StreamingContainerAgent {
 
         } else {
           // buffer server input
-          InetSocketAddress addr = sourceOutput.source.getContainer().bufferServerAddress;
+          PTContainer container = sourceOutput.source.getContainer();
+          InetSocketAddress addr = container.bufferServerAddress;
           if (addr == null) {
             throw new AssertionError("upstream address not assigned: " + sourceOutput);
           }
           inputInfo.bufferServerHost = addr.getHostName();
           inputInfo.bufferServerPort = addr.getPort();
+          inputInfo.bufferServerToken = container.getBufferServerToken();
         }
 
         // On the input side there is a unlikely scenario of partitions even for inline stream that is being

--- a/engine/src/main/java/com/datatorrent/stram/api/ContainerContext.java
+++ b/engine/src/main/java/com/datatorrent/stram/api/ContainerContext.java
@@ -28,6 +28,7 @@ public interface ContainerContext extends Context
 {
   public static final Attribute<String> IDENTIFIER = new Attribute<String>("unknown_container_id");
   public static final Attribute<Integer> BUFFER_SERVER_MB = new Attribute<Integer>(8*64);
+  public static final Attribute<byte[]> BUFFER_SERVER_TOKEN = new Attribute<byte[]>(null, null);
   public static final Attribute<RequestFactory> REQUEST_FACTORY = new Attribute<RequestFactory>(null, null);
   @SuppressWarnings("FieldNameHidesFieldInSuperclass")
   long serialVersionUID = AttributeInitializer.initialize(ContainerContext.class);

--- a/engine/src/main/java/com/datatorrent/stram/api/OperatorDeployInfo.java
+++ b/engine/src/main/java/com/datatorrent/stram/api/OperatorDeployInfo.java
@@ -120,6 +120,7 @@ public class OperatorDeployInfo implements Serializable, OperatorContext
      */
     public String bufferServerHost;
     public int bufferServerPort;
+    public byte[] bufferServerToken;
     /**
      * Class name of tuple SerDe (buffer server stream only).
      */
@@ -212,6 +213,7 @@ public class OperatorDeployInfo implements Serializable, OperatorContext
      */
     public String bufferServerHost;
     public int bufferServerPort;
+    public byte[] bufferServerToken;
     public Map<Integer, StreamCodec<?>> streamCodecs = new HashMap<Integer, StreamCodec<?>>();
     /**
      * Context attributes for output port

--- a/engine/src/main/java/com/datatorrent/stram/engine/StreamContext.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/StreamContext.java
@@ -44,6 +44,7 @@ import com.datatorrent.stram.codec.DefaultStatefulStreamCodec;
 public class StreamContext extends DefaultAttributeMap implements Context
 {
   public static final Attribute<InetSocketAddress> BUFFER_SERVER_ADDRESS = new Attribute<InetSocketAddress>(null, null);
+  public static final Attribute<byte[]> BUFFER_SERVER_TOKEN = new Attribute<byte[]>(null, null);
   public static final Attribute<EventLoop> EVENT_LOOP = new Attribute<EventLoop>(null, null);
   public static final Attribute<StreamCodec<?>> CODEC = new Attribute<StreamCodec<?>>(new DefaultStatefulStreamCodec<Object>(), null);
 

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
@@ -94,6 +94,12 @@ public class PTContainer implements java.io.Serializable
           }
           c.host = in.readString();
           c.nodeHttpAddress = in.readString();
+          int tokenLength = in.readInt();
+          if (tokenLength != -1) {
+            c.bufferServerToken = in.readBytes(tokenLength);
+          } else {
+            c.bufferServerToken = null;
+          }
           break;
         }
       }
@@ -128,6 +134,10 @@ public class PTContainer implements java.io.Serializable
       // host
       out.writeString(container.host);
       out.writeString(container.nodeHttpAddress);
+      out.writeInt((container.bufferServerToken == null) ? -1 : container.bufferServerToken.length);
+      if (container.bufferServerToken != null) {
+        out.write(container.bufferServerToken);
+      }
     }
   }
 
@@ -150,6 +160,8 @@ public class PTContainer implements java.io.Serializable
   int restartAttempts;
   private long startedTime = -1;
   private long finishedTime = -1;
+
+  private byte[] bufferServerToken;
 
   PTContainer(PhysicalPlan plan) {
     this.plan = plan;
@@ -250,6 +262,16 @@ public class PTContainer implements java.io.Serializable
   public void setFinishedTime(long finishedTime)
   {
     this.finishedTime = finishedTime;
+  }
+
+  public byte[] getBufferServerToken()
+  {
+    return bufferServerToken;
+  }
+
+  public void setBufferServerToken(byte[] bufferServerToken)
+  {
+    this.bufferServerToken = bufferServerToken;
   }
 
   public String toIdStateString() {

--- a/engine/src/main/java/com/datatorrent/stram/stream/BufferServerPublisher.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/BufferServerPublisher.java
@@ -17,7 +17,6 @@ package com.datatorrent.stram.stream;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicLong;
-import static java.lang.Thread.sleep;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +32,8 @@ import com.datatorrent.stram.codec.StatefulStreamCodec.DataStatePair;
 import com.datatorrent.stram.engine.ByteCounterStream;
 import com.datatorrent.stram.engine.StreamContext;
 import com.datatorrent.stram.tuple.Tuple;
+
+import static java.lang.Thread.sleep;
 
 /**
  * Implements tuple flow of node to then buffer server in a logical stream<p>
@@ -139,6 +140,7 @@ public class BufferServerPublisher extends Publisher implements ByteCounterStrea
   @SuppressWarnings("unchecked")
   public void activate(StreamContext context)
   {
+    setToken(context.get(StreamContext.BUFFER_SERVER_TOKEN));
     InetSocketAddress address = context.getBufferServerAddress();
     eventloop = context.get(StreamContext.EVENT_LOOP);
     eventloop.connect(address.isUnresolved() ? new InetSocketAddress(address.getHostName(), address.getPort()) : address, this);
@@ -150,6 +152,7 @@ public class BufferServerPublisher extends Publisher implements ByteCounterStrea
   @Override
   public void deactivate()
   {
+    setToken(null);
     eventloop.disconnect(this);
   }
 

--- a/engine/src/main/java/com/datatorrent/stram/stream/BufferServerSubscriber.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/BufferServerSubscriber.java
@@ -84,6 +84,7 @@ public class BufferServerSubscriber extends Subscriber implements ByteCounterStr
   @Override
   public void activate(StreamContext context)
   {
+    setToken(context.get(StreamContext.BUFFER_SERVER_TOKEN));
     InetSocketAddress address = context.getBufferServerAddress();
     eventloop = context.get(StreamContext.EVENT_LOOP);
     eventloop.connect(address.isUnresolved() ? new InetSocketAddress(address.getHostName(), address.getPort()) : address, this);
@@ -140,6 +141,7 @@ public class BufferServerSubscriber extends Subscriber implements ByteCounterStr
   public void deactivate()
   {
     eventloop.disconnect(this);
+    setToken(null);
   }
 
   @Override

--- a/engine/src/main/java/com/datatorrent/stram/stream/FastPublisher.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/FastPublisher.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
-import static java.lang.Thread.sleep;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;
@@ -38,8 +37,12 @@ import com.datatorrent.stram.engine.Stream;
 import com.datatorrent.stram.engine.StreamContext;
 import com.datatorrent.stram.tuple.Tuple;
 
+import static java.lang.Thread.sleep;
+
 /**
  * <p>FastPublisher class.</p>
+ *
+ * TODO:- Implement token security
  *
  * @since 0.3.2
  */

--- a/engine/src/main/java/com/datatorrent/stram/stream/FastSubscriber.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/FastSubscriber.java
@@ -26,6 +26,8 @@ import com.datatorrent.stram.engine.StreamContext;
 /**
  * <p>FastSubscriber class.</p>
  *
+ * TODO:- Implement token security
+ *
  * @since 0.3.2
  */
 public class FastSubscriber extends BufferServerSubscriber


### PR DESCRIPTION
Token authentication for buffer server to authenticate clients before allowing them. Each buffer server is assigned its own token and the clients use the appropriate token when talking to the corresponding server(s). This authentication is enabled only in secure mode and was tested on it.