### PR TITLE
SPOI-5390 migration to jetty 9

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -269,8 +269,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-websocket</artifactId>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-server</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>

--- a/engine/src/test/java/com/datatorrent/stram/StreamingContainerManagerTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/StreamingContainerManagerTest.java
@@ -78,7 +78,7 @@ import com.datatorrent.stram.tuple.Tuple;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 
 public class StreamingContainerManagerTest {
   @Rule public TestMeta testMeta = new TestMeta();
@@ -795,36 +795,29 @@ public class StreamingContainerManagerTest {
     testAppDataSources(dag, false);
   }
 
+  public static class TestWebSocketAdapter extends WebSocketAdapter
+  {
+
+    public static List<JSONObject> messages = new ArrayList<JSONObject>();
+
+    @Override
+    public void onWebSocketText(String data)
+    {
+      try {
+        messages.add(new JSONObject(data));
+      } catch (JSONException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
   @Test
   public void testAppDataPush() throws Exception
   {
     int port = 12345;
     final String topic = "xyz";
-    final List<JSONObject> messages = new ArrayList<JSONObject>();
     EmbeddedWebSocketServer server = new EmbeddedWebSocketServer(port);
-    server.setWebSocket(new WebSocket.OnTextMessage()
-    {
-
-      @Override
-      public void onMessage(String data)
-      {
-        try {
-          messages.add(new JSONObject(data));
-        } catch (JSONException ex) {
-          throw new RuntimeException(ex);
-        }
-      }
-
-      @Override
-      public void onOpen(WebSocket.Connection connection)
-      {
-      }
-
-      @Override
-      public void onClose(int closeCode, String message)
-      {
-      }
-    });
+    server.setWebSocketAdapterClass(TestWebSocketAdapter.class);
     try {
       server.start();
       LogicalPlan dag = new LogicalPlan();
@@ -842,8 +835,8 @@ public class StreamingContainerManagerTest {
       pushAgent.init();
       pushAgent.pushData();
       Thread.sleep(1000);
-      Assert.assertTrue(messages.size() > 0);
-      JSONObject message = messages.get(0);
+      Assert.assertTrue(TestWebSocketAdapter.messages.size() > 0);
+      JSONObject message = TestWebSocketAdapter.messages.get(0);
       System.out.println("Got this message: " + message.toString(2));
       Assert.assertEquals(topic, message.getString("topic"));
       Assert.assertEquals("publish", message.getString("type"));

--- a/engine/src/test/java/com/datatorrent/stram/support/StramTestSupport.java
+++ b/engine/src/test/java/com/datatorrent/stram/support/StramTestSupport.java
@@ -56,13 +56,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.util.Clock;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.websocket.WebSocket;
-import org.eclipse.jetty.websocket.WebSocketServlet;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
 /**
  * Bunch of utilities shared between tests.
@@ -122,9 +122,7 @@ abstract public class StramTestSupport
   /**
    * Create an appPackage zip using the sample appPackage located in
    * src/test/resources/testAppPackage/testAppPackageSrc.
-   * @param file  The file whose path will be used to create the appPackage zip
    * @return      The File object that can be used in the AppPackage constructor.
-   * @throws net.lingala.zip4j.exception.ZipException
    */
   public static File createAppPackageFile()
   {
@@ -540,22 +538,22 @@ abstract public class StramTestSupport
 
     private final int port;
     private Server server;
-    private WebSocket websocket;
+    private Class<? extends WebSocketAdapter> wsAdapterClass;
 
     public EmbeddedWebSocketServer(int port)
     {
       this.port = port;
     }
 
-    public void setWebSocket(WebSocket websocket)
+    public void setWebSocketAdapterClass(Class<? extends WebSocketAdapter> wsAdapterClass)
     {
-      this.websocket = websocket;
+      this.wsAdapterClass = wsAdapterClass;
     }
 
     public void start() throws Exception
     {
       server = new Server();
-      Connector connector = new SelectChannelConnector();
+      ServerConnector connector = new ServerConnector(server);
       connector.setPort(port);
       server.addConnector(connector);
 
@@ -567,9 +565,9 @@ abstract public class StramTestSupport
       WebSocketServlet webSocketServlet = new WebSocketServlet()
       {
         @Override
-        public WebSocket doWebSocketConnect(HttpServletRequest request, String protocol)
+        public void configure(WebSocketServletFactory factory)
         {
-          return websocket;
+          factory.register(wsAdapterClass);
         }
       };
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <github.global.server>github</github.global.server>
     <jackson.version>1.9.2</jackson.version>
     <jersey.version>1.9</jersey.version>
-    <!-- do not change jetty version as later versions have problems with DefaultServlet -->
-    <jetty.version>8.1.10.v20130312</jetty.version>
+    <!-- do not change jetty version to 9.3 or later as it requires JDK 8 -->
+    <jetty.version>9.2.11.v20150529</jetty.version>
     <maven.deploy.repo.classifier></maven.deploy.repo.classifier>
     <license.skip>true</license.skip>
   </properties>


### PR DESCRIPTION
This version has been running on node0:9099 for a couple of days and there has been no problem.  I don't intend to have this merged into the release-3.0 branch.

Also, this is in conjunction with another pull request on DTX.  