### PR TITLE
SPOI-5469 - Datatorrent DTX trigger Jenkins Job fails on timeout

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/stream/InlineStream.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/InlineStream.java
@@ -62,7 +62,6 @@ public class InlineStream extends DefaultReservoir implements Stream, SweepableR
   @Override
   public void deactivate()
   {
-    clear();
   }
 
   /**
@@ -71,7 +70,6 @@ public class InlineStream extends DefaultReservoir implements Stream, SweepableR
   @Override
   public void teardown()
   {
-    clear();
   }
 
   @Override


### PR DESCRIPTION
fixed race condition in InlineStream between upstream operator calling deactivate() and clearing the buffer that serves as input stream for downstream operator and the downstream operator that consumes the buffer.