### PR TITLE
SPOI-5379: Fixing class not found issue due to missing dt-common jar.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StramClient.java
+++ b/engine/src/main/java/com/datatorrent/stram/StramClient.java
@@ -104,6 +104,7 @@ public class StramClient
       com.datatorrent.bufferserver.server.Server.class,
       com.datatorrent.stram.StreamingAppMaster.class,
       com.datatorrent.api.StreamCodec.class,
+      com.datatorrent.common.util.FSStorageAgent.class,
       javax.validation.ConstraintViolationException.class,
       com.ning.http.client.websocket.WebSocketUpgradeHandler.class,
       com.esotericsoftware.kryo.Kryo.class,


### PR DESCRIPTION
dtcli should copy dt-common.jar to HDFS while launching application. This was not happening if none of your operator depends on dt-common classed directly. So adding com.datatorrent.common.util.FsStorageAgent class to required Datatorrent classes list.