### PR TITLE
HA support for stram webservice filter.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/security/StramWSFilterInitializer.java
+++ b/engine/src/main/java/com/datatorrent/stram/security/StramWSFilterInitializer.java
@@ -15,20 +15,25 @@
  */
 package com.datatorrent.stram.security;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.http.FilterContainer;
-import org.apache.hadoop.http.FilterInitializer;
-import org.apache.hadoop.yarn.api.ApplicationConstants;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
-
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.http.FilterContainer;
+import org.apache.hadoop.http.FilterInitializer;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import com.datatorrent.stram.util.ConfigUtils;
 
 /**
- * Borrowed from org.apache.hadoop.yarn.server.webproxy.amfilter.AmFilterIntializer
+ * Based on org.apache.hadoop.yarn.server.webproxy.amfilter.AmFilterIntializer
  * See https://issues.apache.org/jira/browse/YARN-1517
  *
  * @since 0.9.2
@@ -39,14 +44,93 @@ public class StramWSFilterInitializer extends FilterInitializer
   private static final String FILTER_CLASS = StramWSFilter.class.getCanonicalName();
 
   @Override
-  public void initFilter(FilterContainer container, Configuration conf) {
+  public void initFilter(FilterContainer container, Configuration conf)
+  {
     Map<String, String> params = new HashMap<String, String>();
-    String proxy = WebAppUtils.getProxyHostAndPort(conf);
-    String[] parts = proxy.split(":");
-    params.put(StramWSFilter.PROXY_HOST, parts[0]);
-    params.put(StramWSFilter.PROXY_URI_BASE,
-            ConfigUtils.getSchemePrefix(new YarnConfiguration()) + proxy +
-                    System.getenv(ApplicationConstants.APPLICATION_WEB_PROXY_BASE_ENV));
+    Collection<String> proxies = new ArrayList<String>();
+    if (ConfigUtils.isRMHAEnabled(conf)) {
+      // HA is enabled get all
+      for (String rmId : ConfigUtils.getRMHAIds(conf)) {
+        proxies.add(getResolvedRMWebAppURLWithoutScheme(conf, rmId));
+      }
+    }
+    if (proxies.isEmpty()) {
+      proxies.add(getProxyHostAndPort(conf));
+    }
+    StringBuilder proxyBr = new StringBuilder();
+    for (String proxy : proxies) {
+      if (proxyBr.length() != 0) {
+        proxyBr.append(StramWSFilter.PROXY_DELIMITER);
+      }
+      String[] parts = proxy.split(":");
+      proxyBr.append(parts[0]);
+    }
+    params.put(StramWSFilter.PROXY_HOST, proxyBr.toString());
     container.addFilter(FILTER_NAME, FILTER_CLASS, params);
   }
+
+  /*
+    From org.apache.hadoop.yarn.webapp.util.WebAppUtils
+    Reimplementing it as audience for the WebAppUtils is private
+    Using HA enabled methods below
+  */
+  public String getProxyHostAndPort(Configuration conf)
+  {
+    String addr = conf.get(YarnConfiguration.PROXY_ADDRESS);
+    if (addr == null || addr.isEmpty()) {
+      addr = getResolvedRMWebAppURLWithoutScheme(conf, null);
+    }
+    return addr;
+  }
+
+  /*
+    From org.apache.hadoop.yarn.webapp.util.WebAppUtils
+    Modified for HA support
+    Replace with methods from Hadoop when HA support is available
+    HttpConfig is not used as it's audience is private as well and it's interface has changed from Hadoop 2.2 to 2.6
+  */
+  public String getResolvedRMWebAppURLWithoutScheme(Configuration conf, String rmId) {
+    boolean sslEnabled = conf.getBoolean(
+            CommonConfigurationKeysPublic.HADOOP_SSL_ENABLED_KEY,
+            CommonConfigurationKeysPublic.HADOOP_SSL_ENABLED_DEFAULT);
+    return getResolvedRMWebAppURLWithoutScheme(conf, sslEnabled, (rmId != null) ? "." + rmId : null);
+  }
+
+  /*
+    From org.apache.hadoop.yarn.webapp.util.WebAppUtils
+    Modified for HA support
+  */
+  public String getResolvedRMWebAppURLWithoutScheme(Configuration conf, boolean sslEnabled, String rmId)
+  {
+    InetSocketAddress address = null;
+    if (sslEnabled) {
+      address =
+              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_HTTPS_ADDRESS + rmId,
+                      YarnConfiguration.DEFAULT_RM_WEBAPP_HTTPS_ADDRESS,
+                      YarnConfiguration.DEFAULT_RM_WEBAPP_HTTPS_PORT);
+    } else {
+      address =
+              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_ADDRESS + rmId,
+                      YarnConfiguration.DEFAULT_RM_WEBAPP_ADDRESS,
+                      YarnConfiguration.DEFAULT_RM_WEBAPP_PORT);
+    }
+    address = NetUtils.getConnectAddress(address);
+    StringBuffer sb = new StringBuffer();
+    InetAddress resolved = address.getAddress();
+    if (resolved == null || resolved.isAnyLocalAddress() ||
+            resolved.isLoopbackAddress()) {
+      String lh = address.getHostName();
+      try {
+        lh = InetAddress.getLocalHost().getCanonicalHostName();
+      } catch (UnknownHostException e) {
+        //Ignore and fallback.
+      }
+      sb.append(lh);
+    } else {
+      sb.append(address.getHostName());
+    }
+    sb.append(":").append(address.getPort());
+    return sb.toString();
+  }
+
 }

--- a/engine/src/main/java/com/datatorrent/stram/security/StramWSPrincipal.java
+++ b/engine/src/main/java/com/datatorrent/stram/security/StramWSPrincipal.java
@@ -18,7 +18,7 @@ package com.datatorrent.stram.security;
 import java.security.Principal;
 
 /**
- * Borrowed from org.apache.hadoop.yarn.server.webproxy.amfilter.AmIPPrincipal
+ * Based on org.apache.hadoop.yarn.server.webproxy.amfilter.AmIPPrincipal
  * See https://issues.apache.org/jira/browse/YARN-1516
  *
  * @since 0.9.2

--- a/engine/src/main/java/com/datatorrent/stram/util/ConfigUtils.java
+++ b/engine/src/main/java/com/datatorrent/stram/util/ConfigUtils.java
@@ -17,12 +17,15 @@ package com.datatorrent.stram.util;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.util.Collection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -32,6 +35,12 @@ import org.slf4j.LoggerFactory;
  */
 public class ConfigUtils
 {
+  // TODO: HADOOP UPGRADE - replace with YarnConfiguration constants
+  private static final String RM_HA_PREFIX = YarnConfiguration.RM_PREFIX + "ha.";
+  public static final String RM_HA_ENABLED = RM_HA_PREFIX + "enabled";
+  public static final String RM_HA_IDS = RM_HA_PREFIX + "rm-ids";
+  public static final boolean DEFAULT_RM_HA_ENABLED = false;
+
   private static String yarnLogDir;
   private static final Logger LOG = LoggerFactory.getLogger(ConfigUtils.class);
 
@@ -137,6 +146,16 @@ public class ConfigUtils
       }
     }
     return null;
+  }
+
+  public static boolean isRMHAEnabled(Configuration conf)
+  {
+    return conf.getBoolean(RM_HA_ENABLED, DEFAULT_RM_HA_ENABLED);
+  }
+
+  public static Collection<String> getRMHAIds(Configuration conf)
+  {
+    return conf.getStringCollection(RM_HA_IDS);
   }
 
   private static String getDefineValue(String optString, String name)


### PR DESCRIPTION
HA support for webservice filter. Removed dependencies in filter to hadoop classes with private audience as their interface has changed from Hadoop 2.2 to 2.6. Doc updates.