### PR TITLE
APEX-36: calling tmp file '_tmp' instead of '._COPYING_' which is res…

### DIFF
--- a/common/src/main/java/com/datatorrent/common/util/FSStorageAgent.java
+++ b/common/src/main/java/com/datatorrent/common/util/FSStorageAgent.java
@@ -42,7 +42,7 @@ import com.datatorrent.netlet.util.DTThrowable;
  */
 public class FSStorageAgent implements StorageAgent, Serializable
 {
-  public static final String TMP_FILE = "._COPYING_";
+  public static final String TMP_FILE = "_tmp";
   protected static final String STATELESS_CHECKPOINT_WINDOW_ID = Long.toHexString(Stateless.WINDOW_ID);
   public final String path;
   protected final transient FileContext fileContext;


### PR DESCRIPTION
…erved by hadoop